### PR TITLE
Add feature to handle server errors after the user submits

### DIFF
--- a/src/wizard.component.ts
+++ b/src/wizard.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, ContentChildren, QueryList, AfterContentInit } from '@angular/core';
+import { Component, Output, Input, EventEmitter, ContentChildren, QueryList, AfterContentInit } from '@angular/core';
 import { WizardStepComponent } from './wizard-step.component';
 
 @Component({
@@ -41,6 +41,7 @@ export class WizardComponent implements AfterContentInit {
   private _steps: Array<WizardStepComponent> = [];
   private _isCompleted: boolean = false;
 
+  @Input() forceStep: number; 
   @Output()
   onStepChanged: EventEmitter<WizardStepComponent> = new EventEmitter<WizardStepComponent>();
 
@@ -48,8 +49,16 @@ export class WizardComponent implements AfterContentInit {
 
   ngAfterContentInit() {
     this.wizardSteps.forEach(step => this._steps.push(step));
-    this.steps[0].isActive = true;
+    if (this.steps.length) {
+      this.steps[0].isActive = true;
+    }
   }
+
+  public revertToStep(stepIndex: any) {
+    this._isCompleted = false;
+    let nextStep: WizardStepComponent = this.steps[stepIndex];
+    this.goToStep(nextStep);
+  };
 
   get steps(): Array<WizardStepComponent> {
     return this._steps.filter(step => !step.hidden);

--- a/src/wizard.component.ts
+++ b/src/wizard.component.ts
@@ -1,8 +1,8 @@
-import { Component, Output, Input, EventEmitter, ContentChildren, QueryList, AfterContentInit } from '@angular/core';
+import { Component, Output, Input, EventEmitter, ContentChildren, QueryList, AfterContentInit, OnChanges } from '@angular/core';
 import { WizardStepComponent } from './wizard-step.component';
 
 @Component({
-  selector: 'form-wizard',
+  selector: 'wizard',
   template:
   `<div class="card">
     <div class="card-header">
@@ -34,7 +34,7 @@ import { WizardStepComponent } from './wizard-step.component';
     '.completed { cursor: default; }'
   ]
 })
-export class WizardComponent implements AfterContentInit {
+export class WizardComponent implements AfterContentInit, OnChanges {
   @ContentChildren(WizardStepComponent)
   wizardSteps: QueryList<WizardStepComponent>;
 
@@ -54,11 +54,11 @@ export class WizardComponent implements AfterContentInit {
     }
   }
 
-  public revertToStep(stepIndex: any) {
-    this._isCompleted = false;
-    let nextStep: WizardStepComponent = this.steps[stepIndex];
-    this.goToStep(nextStep);
-  };
+  ngOnChanges() {
+    if (this.forceStep) {
+      this.revertToStep(this.forceStep);
+    }  
+  }
 
   get steps(): Array<WizardStepComponent> {
     return this._steps.filter(step => !step.hidden);
@@ -97,6 +97,12 @@ export class WizardComponent implements AfterContentInit {
       this.activeStep = step;
     }
   }
+
+  public revertToStep(stepIndex: any) {
+    this._isCompleted = false;
+    let nextStep: WizardStepComponent = this.steps[stepIndex];
+    this.goToStep(nextStep);
+  };
 
   public next(): void {
     if (this.hasNextStep) {

--- a/src/wizard.component.ts
+++ b/src/wizard.component.ts
@@ -2,7 +2,7 @@ import { Component, Output, Input, EventEmitter, ContentChildren, QueryList, Aft
 import { WizardStepComponent } from './wizard-step.component';
 
 @Component({
-  selector: 'wizard',
+  selector: 'form-wizard',
   template:
   `<div class="card">
     <div class="card-header">


### PR DESCRIPTION
This feature is meant to solve issue #6 "How to handle error case on Done?". I added a revertToStep method which sets _isComplete back to false and then returns the user back to the specified step. The revertToStep method will is fired by adding forceStep and the step number to the error handler portion of your post method. Here is an example:

`postForm() {
   ... 
  }, (error) => {
    this.forceStep = 1;
  }
}`


  